### PR TITLE
Fix ModuleDB parser by skipping commented and empty lines

### DIFF
--- a/src/main/java/ghidra_irx/ModuleDB.java
+++ b/src/main/java/ghidra_irx/ModuleDB.java
@@ -16,8 +16,12 @@ public class ModuleDB {
         BufferedReader reader = new BufferedReader(new FileReader(file));
 
         String line = "";
-        while ( (line = reader.readLine()) != null)
+        while ((line = reader.readLine()) != null)
         {
+            if (line.trim().length() == 0 || line.charAt(0) == '#') {
+                continue;
+            }
+
             String[] entry = line.split(" ");
             if (!db.containsKey(entry[0])) {
                 db.put(entry[0], new Hashtable<>());


### PR DESCRIPTION
This is a simple fix which skips the loop iteration if the line starts with a `#` or is empty after trimming whitespace.

I came across this plugin attempting to RE parts of Buzz, and I did not want to go through the hassle of setting up a Ghidra DE for this small issue, so I committed my fix, downloaded the resulting artefact from GitHub Actions, loaded it into Ghidra, and made sure it worked.

Fixes #10 