### PR TITLE
ci: Use an up to date Ghidra setup action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
           architecture: x64
           
       - name: Setup Ghidra
-        uses: er28-0652/setup-ghidra@b53614dada0a16e3c342277caae905b96d803109
+        uses: antoniovazquezblanco/setup-ghidra@v2.0.6
         with:
           version: ${{ matrix.ghidra }}
           
@@ -31,13 +31,13 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.6
-          arguments: test -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
+          arguments: test
           
       - name: Build Extension
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: 7.6
-          arguments: buildExtension -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
+          arguments: buildExtension
 
       - name: Upload variants artifact ELF
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Disclaimer: I am the maintainer of the updated setup ghidra action.

PD: I would recommend you to implement multiple versions building if you want to avoid having to build by hand. An example can be found in https://github.com/antoniovazquezblanco/GhidraDeviceTreeBlob/blob/main/.github/workflows/main.yml if you are interested.

Thanks!